### PR TITLE
Replace crypto:sha() with crypto:hash()

### DIFF
--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -171,7 +171,7 @@ websocket_handshake(State=#state{
 			transport=Transport, key=Key, deflate_frame=DeflateFrame},
 		Req, HandlerState) ->
 	%% @todo Change into crypto:hash/2 for R17B+ or when supporting only R16B+.
-	Challenge = base64:encode(crypto:sha(
+	Challenge = base64:encode(crypto:hash(sha,
 		<< Key/binary, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" >>)),
 	Extensions = case DeflateFrame of
 		false -> [];


### PR DESCRIPTION
crypto:sha() is removed in OTP-20.